### PR TITLE
get json from cache store

### DIFF
--- a/cads_worker/worker.py
+++ b/cads_worker/worker.py
@@ -3,8 +3,6 @@ import logging
 import os
 from typing import Any
 
-import cacholote
-
 
 def submit_workflow(
     setup_code: str,
@@ -12,6 +10,7 @@ def submit_workflow(
     kwargs: dict[str, Any] = {},
     metadata: dict[str, Any] = {},
 ) -> str:
+    import cacholote
 
     exec(setup_code, globals())
     logging.info(f"Submitting: {metadata['process_id']}")
@@ -26,10 +25,10 @@ def submit_workflow(
         ),
         io_delete_original=True,
     ):
-        func(metadata=metadata, **kwargs)
         cache_key = cacholote.hexdigestify_python_call(
             func, metadata=metadata, **kwargs
         )
+        func(metadata=metadata, **kwargs)
         cache_dict = json.loads(cacholote.config.SETTINGS["cache_store"][cache_key])
     public_dict = {
         k: {} if k.endswith(":storage_options") else v for k, v in cache_dict.items()


### PR DESCRIPTION
I've implemented a read-only `href` in https://github.com/bopen/cacholote/pull/20
This PR uses cacholote a little differently to achieve the following:
- Get JSON directly from the cache store without re-computing it. This ensures that files in the cache are not duplicated.
- Delete original files (e.g., after copying files in the object storage, delete original files downloaded locally)
 